### PR TITLE
Support ESLint Flat Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Specify the files and/or directories to exclude.
 - Type: `String`
 - Default: `eslint`
 
-Path to `eslint` instance that will be used for linting.
+Path to `eslint` instance that will be used for linting. Set `'eslint/use-at-your-own-risk'` if you want to use the flat config system in ESLint v8. Place an `eslint.config.js` file in the root of your project or set the `ESLINT_USE_FLAT_CONFIG` environment variable to true and pass the option `overrideConfigFile` to the plugin if you are using other config files. You can learn more from [Flat config rollout plans](https://eslint.org/blog/2023/10/flat-config-rollout-plans/) and [Configuration Files (New)](https://eslint.org/docs/latest/use/configure/configuration-files-new).
 
 ### `formatter`
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chokidar": "^3.5.3",
     "eslint-webpack-plugin": "^4.0.1",
     "pathe": "^1.1.1",
-    "vite-plugin-eslint2": "^4.3.1"
+    "vite-plugin-eslint2": "^4.4.0"
   },
   "devDependencies": {
     "@nuxt/module-builder": "latest",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chokidar": "^3.5.3",
     "eslint-webpack-plugin": "^4.0.1",
     "pathe": "^1.1.1",
-    "vite-plugin-eslint": "^1.8.1"
+    "vite-plugin-eslint2": "^4.3.1"
   },
   "devDependencies": {
     "@nuxt/module-builder": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,9 @@ dependencies:
   pathe:
     specifier: ^1.1.1
     version: 1.1.1
-  vite-plugin-eslint:
-    specifier: ^1.8.1
-    version: 1.8.1(eslint@8.45.0)(vite@4.3.9)
+  vite-plugin-eslint2:
+    specifier: ^4.3.1
+    version: 4.3.1(@types/eslint@8.37.0)(eslint@8.45.0)(rollup@3.26.3)(vite@4.3.9)
 
 devDependencies:
   '@nuxt/module-builder':
@@ -255,6 +255,7 @@ packages:
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
@@ -1260,6 +1261,7 @@ packages:
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    dev: true
 
   /@rollup/pluginutils@5.0.2(rollup@3.26.3):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
@@ -1274,6 +1276,21 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.26.3
+
+  /@rollup/pluginutils@5.1.0(rollup@3.26.3):
+    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.26.3
+    dev: false
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -1298,13 +1315,6 @@ packages:
     dependencies:
       '@types/eslint': 8.37.0
       '@types/estree': 1.0.0
-    dev: false
-
-  /@types/eslint@8.21.3:
-    resolution: {integrity: sha512-fa7GkppZVEByMWGbTtE5MbmXWJTVbrjjaS8K6uQj+XtuuUv1fsuPAxhygfqLmsb/Ufb3CV8deFCpiMfAgi00Sw==}
-    dependencies:
-      '@types/estree': 1.0.0
-      '@types/json-schema': 7.0.11
     dev: false
 
   /@types/eslint@8.37.0:
@@ -1988,6 +1998,7 @@ packages:
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       color-convert: 1.9.3
 
@@ -2315,6 +2326,7 @@ packages:
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
@@ -2426,6 +2438,7 @@ packages:
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    requiresBuild: true
     dependencies:
       color-name: 1.1.3
 
@@ -2437,6 +2450,7 @@ packages:
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    requiresBuild: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -3821,6 +3835,7 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
+    requiresBuild: true
 
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -4281,6 +4296,7 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    requiresBuild: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -5782,14 +5798,6 @@ packages:
       yargs: 17.7.1
     dev: true
 
-  /rollup@2.79.1:
-    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
-
   /rollup@3.26.3:
     resolution: {integrity: sha512-7Tin0C8l86TkpcMtXvQu6saWH93nhG3dGQ1/+l5V2TDMceTxO7kDiK6GzbfLWNNxqJXm591PcEZUozZm51ogwQ==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
@@ -6120,6 +6128,7 @@ packages:
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       has-flag: 3.0.0
 
@@ -6691,17 +6700,27 @@ packages:
       vscode-uri: 3.0.7
     dev: true
 
-  /vite-plugin-eslint@1.8.1(eslint@8.45.0)(vite@4.3.9):
-    resolution: {integrity: sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==}
+  /vite-plugin-eslint2@4.3.1(@types/eslint@8.37.0)(eslint@8.45.0)(rollup@3.26.3)(vite@4.3.9):
+    resolution: {integrity: sha512-J2y5cX4B2JQAgdMSrkU9A42y6RqYPAbEar/DaybuXKptj/NdkJBbdZekkm1YHAFeKm4jj2yg+nhE0ghJAWvBTA==}
+    engines: {node: '>=18'}
     peerDependencies:
-      eslint: '>=7'
-      vite: '>=2'
+      '@types/eslint': ^7.0.0 || ^8.0.0
+      eslint: ^7.0.0 || ^8.0.0
+      rollup: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
     dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@types/eslint': 8.21.3
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
+      '@types/eslint': 8.37.0
+      chokidar: 3.5.3
+      debug: 4.3.4
       eslint: 8.45.0
-      rollup: 2.79.1
+      rollup: 3.26.3
       vite: 4.3.9(@types/node@18.15.5)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /vite@4.3.9(@types/node@18.15.5):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^1.1.1
     version: 1.1.1
   vite-plugin-eslint2:
-    specifier: ^4.3.1
-    version: 4.3.1(@types/eslint@8.37.0)(eslint@8.45.0)(rollup@3.26.3)(vite@4.3.9)
+    specifier: ^4.4.0
+    version: 4.4.0(@types/eslint@8.37.0)(eslint@8.45.0)(rollup@3.26.3)(vite@4.3.9)
 
 devDependencies:
   '@nuxt/module-builder':
@@ -1141,7 +1141,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
@@ -1159,7 +1159,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
@@ -1177,7 +1177,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       estree-walker: 2.0.2
       magic-string: 0.27.0
       rollup: 3.26.3
@@ -1192,7 +1192,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       rollup: 3.26.3
     dev: true
 
@@ -1205,7 +1205,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
@@ -1223,7 +1223,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       magic-string: 0.27.0
       rollup: 3.26.3
     dev: true
@@ -1276,6 +1276,7 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.26.3
+    dev: true
 
   /@rollup/pluginutils@5.1.0(rollup@3.26.3):
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
@@ -1290,7 +1291,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.26.3
-    dev: false
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -1666,7 +1666,7 @@ packages:
         optional: true
     dependencies:
       '@babel/types': 7.21.5
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       '@vue/compiler-sfc': 3.3.4
       local-pkg: 0.4.3
       magic-string-ast: 0.1.2
@@ -2384,6 +2384,21 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  /chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
 
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -4713,7 +4728,7 @@ packages:
       '@rollup/plugin-replace': 5.0.2(rollup@3.26.3)
       '@rollup/plugin-terser': 0.4.3(rollup@3.26.3)
       '@rollup/plugin-wasm': 6.1.3(rollup@3.26.3)
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       '@types/http-proxy': 1.17.11
       '@vercel/nft': 0.22.6
       archiver: 5.3.1
@@ -6472,7 +6487,7 @@ packages:
   /unimport@3.0.14(rollup@3.26.3):
     resolution: {integrity: sha512-67Rh/sGpEuVqdHWkXaZ6NOq+I7sKt86o+DUtKeGB6dh4Hk1A8AQrzyVGg2+LaVEYotStH7HwvV9YSaRjyT7Uqg==}
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       escape-string-regexp: 5.0.0
       fast-glob: 3.3.0
       local-pkg: 0.4.3
@@ -6500,7 +6515,7 @@ packages:
         optional: true
     dependencies:
       '@babel/types': 7.21.5
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       '@vue-macros/common': 1.3.1(rollup@3.26.3)(vue@3.3.4)
       ast-walker-scope: 0.4.1
       chokidar: 3.5.3
@@ -6700,12 +6715,12 @@ packages:
       vscode-uri: 3.0.7
     dev: true
 
-  /vite-plugin-eslint2@4.3.1(@types/eslint@8.37.0)(eslint@8.45.0)(rollup@3.26.3)(vite@4.3.9):
-    resolution: {integrity: sha512-J2y5cX4B2JQAgdMSrkU9A42y6RqYPAbEar/DaybuXKptj/NdkJBbdZekkm1YHAFeKm4jj2yg+nhE0ghJAWvBTA==}
+  /vite-plugin-eslint2@4.4.0(@types/eslint@8.37.0)(eslint@8.45.0)(rollup@3.26.3)(vite@4.3.9):
+    resolution: {integrity: sha512-xy5G4Gj18ke1bO5OS0zgyunkPvPy/vSLJFTyMpGmKGKTlYuuhPad3Xy1PWLuqRMoWnuCoFMf2ST1EGhz89uqrA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/eslint': ^7.0.0 || ^8.0.0
-      eslint: ^7.0.0 || ^8.0.0
+      '@types/eslint': ^7.0.0 || ^8.0.0 || ^9.0.0-0
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0-0
       rollup: ^2.0.0 || ^3.0.0 || ^4.0.0
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
@@ -6714,7 +6729,7 @@ packages:
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.26.3)
       '@types/eslint': 8.37.0
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       debug: 4.3.4
       eslint: 8.45.0
       rollup: 3.26.3

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
 import { defineNuxtModule, addVitePlugin, addWebpackPlugin, useLogger } from '@nuxt/kit'
-import type { Options as VitePlugin } from 'vite-plugin-eslint'
+import type { ESLintPluginUserOptions as VitePlugin } from 'vite-plugin-eslint2'
 import type { Options as WebpackPlugin } from 'eslint-webpack-plugin'
-import vitePluginEslint from 'vite-plugin-eslint'
+import vitePluginEslint from 'vite-plugin-eslint2'
 import EslintWebpackPlugin from 'eslint-webpack-plugin'
 import { relative } from 'pathe'
 import { watch } from 'chokidar'
@@ -43,7 +43,10 @@ export default defineNuxtModule<ModuleOptions>({
       '.eslintrc.js',
       '.eslintrc.yaml',
       '.eslintrc.yml',
-      '.eslintrc.json'
+      '.eslintrc.json',
+      'eslint.config.js',
+      'eslint.config.mjs',
+      'eslint.config.cjs'
     ].map(path => relative(nuxt.options.rootDir, path))
 
     if (nuxt.options.watch) {


### PR DESCRIPTION
closes https://github.com/nuxt-modules/eslint/issues/115

1. replace vite-plugin-eslint with vite-plugin-eslint2, which supports flat config, active and maintained by me
2. Just set `eslintPath: 'eslint/use-at-your-own-risk'` and `eslint.config.js`, and flat config should be done

While it would be possible to auto-detect to determine the ESLint version and whether to enable flat config by default, I think this would add unnecessary complexity. I will add this function to the PR if you think it's worth it. Thank you.